### PR TITLE
Better sizing

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -48,7 +48,7 @@
             var pos         = position(el);
             var relativeY   = (e.pageY - pos.top);
             var relativeX   = (e.pageX - pos.left);
-            var width       = el.clientWidth;
+            var radius      = el.clientWidth + el.clientHeight;
 
             // Attach data to element
             ripple.setAttribute('data-hold', Date.now());
@@ -57,7 +57,7 @@
 
             // Start ripple
             var positionStyle = 'top:'+relativeY+'px;left:'+relativeX+'px;';
-            var flowStyle = 'border-width:'+width+'px;margin-top:-'+width+'px;margin-left:-'+width+'px;opacity:1;';
+            var flowStyle = 'border-width:'+radius+'px;margin-top:-'+radius+'px;margin-left:-'+radius+'px;opacity:1;';
 
             ripple.className = ripple.className + ' waves-notransition';
             ripple.setAttribute('style', positionStyle);


### PR DESCRIPTION
When clicking on a corner of an element, the circle [does not extend all the way to the other corner](http://puu.sh/akQ2z/452fd9cf02.png) and looks a bit silly!  While we could use the [diagonal of a rectangle](http://upload.wikimedia.org/math/1/f/b/1fbba66db3cf3139bdb0243ad8ac3e67.png) equation, it's "good enough" just to add the width and height - there's really no need to do the whole calculation.

This PR modifies the script so that the radius of the circle is equal to the width plus the height of the button, so there's no gap.
