### PR TITLE
Minor LESS tidy up for .waves-notransition

### DIFF
--- a/src/less/waves.less
+++ b/src/less/waves.less
@@ -57,10 +57,7 @@
 }
 
 .waves-notransition {
-    -webkit-transition: none !important;  
-    -moz-transition: none !important; 
-    -o-transition: none !important;
-    transition: none !important; 
+    .transition(none !important);
 }
 
 .waves-button, 


### PR DESCRIPTION
It's tiny and petty. Just making `.waves-notransition` use the `.transition(@transition)` mixin.
