### PR TITLE
(v0.6.0-dev) Added stylus support with grunt and less2style (#59)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,37 @@ module.exports = function(grunt) {
             }
 		},
         
+        //convert less to stylus
+        execute: {
+            less2stylus2: {
+                options: {
+                    cwd: './node_modules/less2stylus',
+                },
+                call: function(grunt, options, async) {
+                    var done = async();
+                    var exec = require('child_process').exec;
+                    exec('cd node_modules/less2stylus && ./less2stylus ../../src/less/waves.less', function (error, stdout, stderr) {
+                        grunt.log.writeln('Executing less2styus...');
+
+                        if (error) {
+                            grunt.log.writeln('Error! ' + error);
+                        }
+
+                        var fs = require('fs');
+                        fs.writeFile("src/stylus/waves.styl", stdout, function(err) {
+                            if(err) {
+                                grunt.log.writeln(err);
+                            } else {
+                                grunt.log.writeln("Stylus file was saved!");
+                            }
+
+                            done(); // let grunt resume
+                        });
+                    });
+                }
+            }
+        },
+
         watch: {
             script: {
                options: {
@@ -69,7 +100,7 @@ module.exports = function(grunt) {
                     event: ['added', 'deleted', 'changed']
                 },
                 files: ['src/**/*'],
-                tasks: ['less', 'jshint', 'uglify', 'copy']
+                tasks: ['less', 'jshint', 'uglify', 'copy', 'execute']
             },
             grunt: {
                 files: ['Gruntfile.js']
@@ -84,8 +115,9 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-execute');
     
     // Create grunt task
-    grunt.registerTask('build', ['less', 'jshint', 'uglify', 'copy']);
+    grunt.registerTask('build', ['less', 'jshint', 'uglify', 'copy', 'execute']);
     grunt.registerTask('default', ['watch']);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-less": "^0.12.0",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-execute": "^0.2.2",
+    "less2stylus": "^0.1.0"
   },
   "scripts": {
     "test": ""

--- a/src/stylus/waves.styl
+++ b/src/stylus/waves.styl
@@ -1,0 +1,116 @@
+lesscss-percentage(n)
+  (n * 100)%
+/*!
+ * Waves v0.6.0-dev
+ * http://fian.my.id/Waves 
+ * 
+ * Copyright 2014 Alfiana E. Sibuea and other contributors 
+ * Released under the MIT license 
+ * https://github.com/fians/Waves/blob/master/LICENSE 
+ */
+transition(transition)
+  -webkit-transition transition
+  -moz-transition transition
+  -o-transition transition
+  transition transition
+transform(string)
+  -webkit-transform string
+  -moz-transform string
+  -ms-transform string
+  -o-transform string
+  transform string
+box-shadow(shadow)
+  -webkit-box-shadow shadow
+  box-shadow shadow
+.waves-effect
+  position relative
+  cursor pointer
+  display inline-block
+  overflow hidden
+  -webkit-user-select none
+  -moz-user-select none
+  -ms-user-select none
+  user-select none
+  -webkit-tap-highlight-color transparent
+  transition(all 0.3s ease-out)
+  .waves-ripple
+    position absolute
+    border-radius 50%
+    width 100px
+    height 100px
+    margin-top -50px
+    margin-left -50px
+    opacity 0
+    background rgba(0, 0, 0, 0.2)
+    gradient = rgba(0, 0, 0, 0.15) 0, rgba(0, 0, 0, 0.3) 40%, rgba(0, 0, 0, 0.4) 50%, rgba(0, 0, 0, 0.4) 60%, rgba(0, 0, 0, 0) 70%
+    background -webkit-radial-gradient(gradient)
+    background -o-radial-gradient(gradient)
+    background -moz-radial-gradient(gradient)
+    background radial-gradient(gradient)
+    transition(all 0.5s ease-out)
+    -webkit-transition-property -webkit-transform, opacity
+    -moz-transition-property -moz-transform, opacity
+    -o-transition-property -o-transform, opacity
+    transition-property transform, opacity
+    transform(scale(0))
+    pointer-events none
+  &.waves-light .waves-ripple
+    background rgba(255, 255, 255, 0.4)
+    gradient = rgba(255, 255, 255, 0.15) 0, rgba(255, 255, 255, 0.3) 40%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.4) 60%, rgba(255, 255, 255, 0) 70%
+    background -webkit-radial-gradient(gradient)
+    background -o-radial-gradient(gradient)
+    background -moz-radial-gradient(gradient)
+    background radial-gradient(gradient)
+  &.waves-classic .waves-ripple
+    background rgba(0, 0, 0, 0.2)
+  &.waves-classic.waves-light .waves-ripple
+    background rgba(255, 255, 255, 0.4)
+.waves-notransition
+  transition(none)
+.waves-button, .waves-circle
+  transform(translateZ(0))
+  -webkit-mask-image -webkit-radial-gradient(circle, rgb(255, 255, 255, 1) 100%, rgb(0, 0, 0, 1) 100%)
+.waves-button, .waves-button:hover, .waves-button:visited, .waves-button:link, .waves-button-input
+  white-space nowrap
+  vertical-align middle
+  cursor pointer
+  border none
+  outline none
+  color inherit
+  background-color rgba(0, 0, 0, 0)
+  font-size 14px
+  text-align center
+  text-decoration none
+  z-index 1
+.waves-button
+  padding 10px 15px
+  border-radius 2px
+.waves-button-input
+  margin 0
+  padding 10px 15px
+.waves-input-wrapper
+  border-radius 2px
+  vertical-align bottom
+  &.waves-button
+    padding 0
+  .waves-button-input
+    position relative
+    top 0
+    left 0
+    z-index 1
+.waves-circle
+  text-align center
+  width 2.5em
+  height 2.5em
+  line-height 2.5em
+  border-radius 50%
+.waves-float
+  -webkit-mask-image none
+  box-shadow(0px 1px 1.5px 1px rgba(0, 0, 0, 0.12))
+  &:active
+    box-shadow(0px 8px 20px 1px rgba(0, 0, 0, 0.3))
+.waves-block
+  display block
+/* Firefox Bug: link not triggered */
+a.waves-effect .waves-ripple
+  z-index -1


### PR DESCRIPTION
All automated in grunt using the npm packages `less2style` and kicking the process off with `grunt-execute`. See the changes in `Gruntfile.js` for how it works. :smile:

Should hopefully solve feature request #59. I wonder if we can automate the SCSS and SASS? I think I might be able to do some regex stuff for SCSS support following [this article](http://mstrutt.co.uk/blog/2013/08/converting-from-less-to-sass/), and then maybe we can test the compilation somehow. (Maybe by compiling them to a temp/ folder and check the compiled files aren't empty? All with `grunt-execute` of course.)

**Warning:** I haven't tried to compile the Stylus code; I've just assumed it works?

PS. how do you run local node packages? Running `node_modules/less2stylus/less2stylus` seems messy and long, I've a feeling I'm being blind and missing a `node run <local package>` or something?
