### PR TITLE
Fix IE Tap section's Wave initializer demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -482,8 +482,7 @@ $('#snarl-demo').click(function() {
 
         <script type="text/javascript" src="/path/to/waves.js">\</script\>
         <script type="text/javascript">
-            var w = new Waves();
-            w.displayEffect();
+            Waves.displayEffect();
         </script>
     </body>
 </html>


### PR DESCRIPTION
I noticed that the Waves init example in the last section of the docs was incorrect. Here's a fix.