### PR TITLE
Added optional timeout before showing waves effect

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -7,13 +7,14 @@
  * https://github.com/fians/Waves/blob/master/LICENSE 
  */
 
-;(function(window, factory) {
+;
+(function (window, factory) {
     "use strict";
 
     // AMD. Register as an anonymous module.  Wrap in function so we have access
     // to root via `this`.
     if (typeof define === "function" && define.amd) {
-        define([], function() {
+        define([], function () {
             return factory.apply(window);
         });
     }
@@ -33,6 +34,7 @@
 
     var Waves = Waves || {};
     var $$ = document.querySelectorAll.bind(document);
+    var isTouchAvailable = 'ontouchstart' in this;
 
     // Find exact position of element
     function isWindow(obj) {
@@ -45,7 +47,7 @@
 
     function offset(elem) {
         var docElem, win,
-            box = {top: 0, left: 0},
+            box = {top : 0, left : 0},
             doc = elem && elem.ownerDocument;
 
         docElem = doc.documentElement;
@@ -55,8 +57,8 @@
         }
         win = getWindow(doc);
         return {
-            top: box.top + win.pageYOffset - docElem.clientTop,
-            left: box.left + win.pageXOffset - docElem.clientLeft
+            top  : box.top + win.pageYOffset - docElem.clientTop,
+            left : box.left + win.pageXOffset - docElem.clientLeft
         };
     }
 
@@ -75,9 +77,16 @@
     var Effect = {
 
         // Effect delay
-        duration: 750,
+        duration   : 750,
 
-        show: function(e, element) {
+        // Timeout before start of effect
+        timeout    : 0,
+
+        // if true touchmove event will from effect from showing
+        // it work in combination with non zero timeout
+        stopOnMove : false,
+
+        show : function (e, element) {
 
             // Disable right click
             if (e.button === 2) {
@@ -92,15 +101,15 @@
             el.appendChild(ripple);
 
             // Get click coordinate and element witdh
-            var pos         = offset(el);
-            var relativeY   = (e.pageY - pos.top);
-            var relativeX   = (e.pageX - pos.left);
-            var scale       = 'scale('+((el.clientWidth / 100) * 3)+')';
-            
+            var pos = offset(el);
+            var relativeY = (e.pageY - pos.top);
+            var relativeX = (e.pageX - pos.left);
+            var scale = 'scale(' + ((el.clientWidth / 100) * 3) + ')';
+
             // Support for touch devices
-            if ('touches' in e) {
-              relativeY   = (e.touches[0].pageY - pos.top);
-              relativeX   = (e.touches[0].pageX - pos.left);
+            if ('touches' in e && e.touches.length) {
+                relativeY = (e.touches[0].pageY - pos.top);
+                relativeX = (e.touches[0].pageX - pos.left);
             }
 
             // Attach data to element
@@ -111,10 +120,10 @@
 
             // Set ripple position
             var rippleStyle = {
-                'top': relativeY+'px',
-                'left': relativeX+'px'
+                'top'  : relativeY + 'px',
+                'left' : relativeX + 'px'
             };
-            
+
             ripple.className = ripple.className + ' waves-notransition';
             ripple.setAttribute('style', convertStyle(rippleStyle));
             ripple.className = ripple.className.replace('waves-notransition', '');
@@ -125,22 +134,22 @@
             rippleStyle['-ms-transform'] = scale;
             rippleStyle['-o-transform'] = scale;
             rippleStyle.transform = scale;
-            rippleStyle.opacity   = '1';
+            rippleStyle.opacity = '1';
 
             rippleStyle['-webkit-transition-duration'] = Effect.duration + 'ms';
-            rippleStyle['-moz-transition-duration']    = Effect.duration + 'ms';
-            rippleStyle['-o-transition-duration']      = Effect.duration + 'ms';
-            rippleStyle['transition-duration']         = Effect.duration + 'ms';
+            rippleStyle['-moz-transition-duration'] = Effect.duration + 'ms';
+            rippleStyle['-o-transition-duration'] = Effect.duration + 'ms';
+            rippleStyle['transition-duration'] = Effect.duration + 'ms';
 
             ripple.setAttribute('style', convertStyle(rippleStyle));
         },
 
-        hide: function(e) {
+        hide      : function (e) {
             TouchHandler.touchup(e);
 
             var el = this;
             var width = el.clientWidth * 1.4;
-            
+
             // Get first ripple
             var ripple = null;
             var ripples = el.getElementsByClassName('waves-ripple');
@@ -150,9 +159,9 @@
                 return false;
             }
 
-            var relativeX   = ripple.getAttribute('data-x');
-            var relativeY   = ripple.getAttribute('data-y');
-            var scale       = ripple.getAttribute('data-scale');
+            var relativeX = ripple.getAttribute('data-x');
+            var relativeY = ripple.getAttribute('data-y');
+            var scale = ripple.getAttribute('data-scale');
 
             // Get delay beetween mousedown and mouse leave
             var diff = Date.now() - Number(ripple.getAttribute('data-hold'));
@@ -163,30 +172,30 @@
             }
 
             // Fade out ripple after delay
-            setTimeout(function() {
+            setTimeout(function () {
                 var style = {
-                    'top': relativeY+'px',
-                    'left': relativeX+'px',
-                    'opacity': '0',
+                    'top'                         : relativeY + 'px',
+                    'left'                        : relativeX + 'px',
+                    'opacity'                     : '0',
 
                     // Duration
-                    '-webkit-transition-duration': Effect.duration + 'ms',
-                    '-moz-transition-duration': Effect.duration + 'ms',
-                    '-o-transition-duration': Effect.duration + 'ms',
-                    'transition-duration': Effect.duration + 'ms',
-                    '-webkit-transform': scale,
-                    '-moz-transform': scale,
-                    '-ms-transform': scale,
-                    '-o-transform': scale,
-                    'transform': scale,
+                    '-webkit-transition-duration' : Effect.duration + 'ms',
+                    '-moz-transition-duration'    : Effect.duration + 'ms',
+                    '-o-transition-duration'      : Effect.duration + 'ms',
+                    'transition-duration'         : Effect.duration + 'ms',
+                    '-webkit-transform'           : scale,
+                    '-moz-transform'              : scale,
+                    '-ms-transform'               : scale,
+                    '-o-transform'                : scale,
+                    'transform'                   : scale,
                 };
 
                 ripple.setAttribute('style', convertStyle(style));
 
-                setTimeout(function() {
+                setTimeout(function () {
                     try {
                         el.removeChild(ripple);
-                    } catch(e) {
+                    } catch (e) {
                         return false;
                     }
                 }, Effect.duration);
@@ -194,10 +203,10 @@
         },
 
         // Little hack to make <input> can perform waves effect
-        wrapInput: function(elements) {
+        wrapInput : function (elements) {
             for (var a = 0; a < elements.length; a++) {
                 var el = elements[a];
-                
+
                 if (el.tagName.toLowerCase() === 'input') {
                     var parent = el.parentNode;
 
@@ -217,7 +226,7 @@
                     }
 
                     wrapper.setAttribute('style', elementStyle);
-                    
+
                     el.className = 'waves-button-input';
                     el.removeAttribute('style');
 
@@ -238,14 +247,14 @@
          * needing to clear timeouts if another touch event occurred
          * within the 500ms. Cannot mouseup between touchstart and
          * touchend, nor in the 500ms after touchend. */
-        touches: 0,
-        allowEvent: function(e) {
+        touches    : 0,
+        allowEvent : function (e) {
             var allow = true;
 
             if (e.type === 'touchstart') {
                 TouchHandler.touches += 1; //push
             } else if (e.type === 'touchend' || e.type === 'touchcancel') {
-                setTimeout(function() {
+                setTimeout(function () {
                     if (TouchHandler.touches > 0) {
                         TouchHandler.touches -= 1; //pop after 500ms
                     }
@@ -256,7 +265,7 @@
 
             return allow;
         },
-        touchup: function(e) {
+        touchup    : function (e) {
             TouchHandler.allowEvent(e);
         }
     };
@@ -295,32 +304,59 @@
         var element = getWavesEffectElement(e);
 
         if (element !== null) {
-            Effect.show(e, element);
+            // setting the timer for possible timeout of showing effect
+            var timer = setTimeout(function () {
+                Effect.show(e, element);
+            }, Effect.timeout);
+            
+            var hideEffect = function (e) {
+                var me = this;
+                // start hide effect after timeout
+                // otherwise show effect can appear after hide effect
+                setTimeout(function () {
+                    Effect.hide.call(me, e);
+                }, Effect.timeout);
+            };
 
-            if ('ontouchstart' in window) {
-                element.addEventListener('touchend', Effect.hide, false);
-                element.addEventListener('touchcancel', Effect.hide, false);
+            if (isTouchAvailable) {
+                var touchMove = function () {
+                    // if touchmove event show prevent show effect to appear
+                    // then clear the timeout
+                    if (Effect.stopOnMove) {
+                        clearTimeout(timer);
+                    }
+                }
+
+                element.addEventListener('touchmove', touchMove, false);
+                element.addEventListener('touchend', hideEffect, false);
+                element.addEventListener('touchcancel', hideEffect, false);
             }
 
-            element.addEventListener('mouseup', Effect.hide, false);
-            element.addEventListener('mouseleave', Effect.hide, false);
+            element.addEventListener('mouseup', hideEffect, false);
+            element.addEventListener('mouseleave', hideEffect, false);
         }
     }
 
-    Waves.displayEffect = function(options) {
+    Waves.displayEffect = function (options) {
         options = options || {};
 
         if ('duration' in options) {
             Effect.duration = options.duration;
         }
-        
+        if ('timeout' in options) {
+            Effect.timeout = options.timeout;
+        }
+        if ('stopOnMove' in options) {
+            Effect.stopOnMove = options.stopOnMove;
+        }
+
         //Wrap input inside <i> tag
         Effect.wrapInput($$('.waves-effect'));
-        
-        if ('ontouchstart' in window) {
+
+        if (isTouchAvailable) {
             document.body.addEventListener('touchstart', showEffect, false);
         }
-        
+
         document.body.addEventListener('mousedown', showEffect, false);
     };
 
@@ -330,7 +366,7 @@
      *   Intended to be used with dynamically loaded forms/inputs, or
      * where the user doesn't want a delegated click handler.
      */
-    Waves.attach = function(element) {
+    Waves.attach = function (element) {
         //FUTURE: automatically add waves classes and allow users
         // to specify them with an options param? Eg. light/classic/button
         if (element.tagName.toLowerCase() === 'input') {
@@ -338,7 +374,7 @@
             element = element.parentElement;
         }
 
-        if ('ontouchstart' in window) {
+        if (isTouchAvailable) {
             element.addEventListener('touchstart', showEffect, false);
         }
 


### PR DESCRIPTION
Added possibility to set timeout before showing waves effect and ability to cancel showing of waves effect on touchmove event.
The thing is that when you scroll the list of elements with wave effect as soon as you touched element to scroll it'll show the effect but instead of that you want just to scroll the list without showing any effect, so by setting options "timeout" at least 100ms and "stopOnMove" to true you can prevent waves effect while scrolling but still have it when you just tap on element.