### PR TITLE
prevent adding 'waves-effect' multiple times in case of lazy loading templates (ajax, angularjs, ...) when Waves.attach(...) is called multiple times

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -477,7 +477,9 @@
                 element = element.parentElement;
             }
 
-            element.className += ' waves-effect' + classes;
+            if (element.className.indexOf('waves-effect') === -1) {
+				element.className += ' waves-effect' + classes;
+			}
         }
     };
 


### PR DESCRIPTION
prevent adding 'waves-effect' multiple times in case of lazy loading templates (ajax, angularjs, ...) when Waves.attach(...) is called multiple times.

A different approach to this would be to attach to elements without 'waves-effect' using CSS selectors.