### PR TITLE
.attach() can now identify array of elements.

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -60,7 +60,7 @@
 
         if (stringRepr === '[object String]') {
             return $$(nodes);
-        } else if (isObject(nodes) && /^\[object (HTMLCollection|NodeList|Object)\]$/.test(stringRepr) && nodes.hasOwnProperty('length')) {
+        } else if (isObject(nodes) && /^\[object (Array|HTMLCollection|NodeList|Object)\]$/.test(stringRepr) && nodes.hasOwnProperty('length')) {
             return nodes;
         } else if (isDOMNode(nodes)) {
             return [nodes];


### PR DESCRIPTION
Resolves #148 - a simple array of DOM elements is not matched.