### PR TITLE
Add option to specify which elements to apply the effect to

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -105,6 +105,10 @@
 
         // Effect delay (check for scroll before showing effect)
         delay: 200,
+        
+        // Selector to find element to apply effect to.
+        // Can contain multiple classes (like ".btn, .nav a")
+        elementSelector: ".waves-effect",
 
         show: function(e, element, velocity) {
 
@@ -357,6 +361,18 @@
         }
     };
 
+    /**
+     * Browser-compatible version of Element.matches().
+     */
+    function matches(element, selector) {
+        var matches = document.documentElement.matches ||
+            document.documentElement.matchesSelector ||
+            document.documentElement.webkitMatchesSelector ||
+            document.documentElement.mozMatchesSelector ||
+            document.documentElement.msMatchesSelector ||
+            document.documentElement.oMatchesSelector;
+        return matches.call(element, selector);
+    }
 
     /**
      * Delegated click handler for .waves-effect element.
@@ -372,7 +388,7 @@
         var target = e.target || e.srcElement;
 
         while (target.parentElement) {
-            if ( (!(target instanceof SVGElement)) && target.classList.contains('waves-effect')) {
+            if ( (!(target instanceof SVGElement)) && matches(target, Effect.elementSelector)) {
                 element = target;
                 break;
             }
@@ -474,6 +490,10 @@
 
         if ('delay' in options) {
             Effect.delay = options.delay;
+        }
+
+        if ('elementSelector' in options) {
+            Effect.elementSelector = options.elementSelector;
         }
 
         if (isTouchAvailable) {


### PR DESCRIPTION
When DOM elements are rendered after the page loads, the Waves effect must be attached to those elements (again). To make this much more convenient, I propose an option where users can decide which elements the Waves effect applies to at init time.

That means you can do something like this:
```js
	Waves.init({elementSelector: ".waves-effect, .btn"});
```

And add the necessary styles (in SASS):
```scss
.btn {
  @extend .waves-effect;
}
```

No need for ```Waves.attach``` at all anymore.