### PR TITLE
Update waves TypeScript definition

### DIFF
--- a/src/typings/waves.d.ts
+++ b/src/typings/waves.d.ts
@@ -1,9 +1,9 @@
 type ElementSelector = string | HTMLElement | HTMLElement[];
 
-export function init(config?: { duration?: number, delay?: number });
+export function init(config?: { duration?: number, delay?: number }): void;
 
-export function attach(elements: ElementSelector, classes?: string | string[]);
+export function attach(elements: ElementSelector, classes?: string | string[]): void;
 
-export function ripple(elements: ElementSelector, option?: { wait?: number, position?: { x: number, y: number }});
+export function ripple(elements: ElementSelector, option?: { wait?: number, position?: { x: number, y: number }}): void;
 
-export function calm(elements: ElementSelector);
+export function calm(elements: ElementSelector): void;


### PR DESCRIPTION
Add a return-type annotation to Waves functions for working with the "noImplicitAny" TypeScript compilerOption.