### PR TITLE
Remove position: relative for better usability

### DIFF
--- a/src/scss/waves.scss
+++ b/src/scss/waves.scss
@@ -29,7 +29,6 @@
 }
 
 .waves-effect {
-    position: relative;
     cursor: pointer;
     display: inline-block;
     overflow: hidden;


### PR DESCRIPTION
Removed `position: relative;` from `.waves-effect` in line 32.

I believe it's a better approach to let the developer/designer define the position. In most cases, this plugin is integrated after layout is done, in which case everything will be in place already and properly styled. Plus, many will use this for Material Design Action Buttons, in which case `position: absolute;` is preffered. Such as in my usecase of this plugin.

Other than that, fantastic work! Good job.