### PR TITLE
Fixed dead link in documentation

### DIFF
--- a/docs/_pages/examples.html
+++ b/docs/_pages/examples.html
@@ -110,7 +110,7 @@
             <i class="fa fa-code"></i>
         </a>
 
-        <p>Works fully with jQuery and JavaScript click event handlers, like <a href="http://hoxxep.github.io/snarl/" target="_blank">Snarl</a></p>
+        <p>Works fully with jQuery and JavaScript click event handlers, like <a href="https://hoxxep.github.io/snarl/" target="_blank">Snarl</a></p>
 
         <style>
             #snarl-demo {

--- a/docs/_pages/examples.html
+++ b/docs/_pages/examples.html
@@ -110,7 +110,7 @@
             <i class="fa fa-code"></i>
         </a>
 
-        <p>Works fully with jQuery and JavaScript click event handlers, like <a href="http://hoxxep.github.io/Snarl" target="_blank">Snarl</a></p>
+        <p>Works fully with jQuery and JavaScript click event handlers, like <a href="http://hoxxep.github.io/snarl/" target="_blank">Snarl</a></p>
 
         <style>
             #snarl-demo {


### PR DESCRIPTION
Fixed a dead link to [Snarl](http://hoxxep.github.io/snarl/) on the examples page.