### PR TITLE
explicitely define window.Waves

### DIFF
--- a/src/js/waves.js
+++ b/src/js/waves.js
@@ -14,7 +14,7 @@
     // to root via `this`.
     if (typeof define === 'function' && define.amd) {
         define([], function() {
-            return factory.apply(window);
+            return window.Waves = factory.apply(window);
         });
     }
 


### PR DESCRIPTION
See https://github.com/bebraw/libumd/blob/master/templates/returnExportsGlobal.hbs#L24 and other scripts with the same issue.

Reference: https://github.com/fians/Waves/issues/131